### PR TITLE
Documentation fixes + EnvelopeMessages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Follow these instructions to set up a local development environment and contribu
 1. **Clone the Repository:**
 
    ```bash
-   git clone --depth 1 https://github.com/YourGitHubUsername/liveapi-documentation liveapi-documentation
+   git clone --depth 1 https://github.com/YourGitHubUsername/apex-liveapi-documentation liveapi-documentation
    cd liveapi-documentation
    ```
 
@@ -44,7 +44,7 @@ We welcome contributions to the LiveAPI Documentation! To contribute:
 2. **Clone Your Fork:**
 
    ```bash
-   git clone https://github.com/YourUsername/liveapi-documentation
+   git clone https://github.com/YourUsername/apex-liveapi-documentation
    cd liveapi-documentation
    ```
 3. **Add the Custom Lotus Submodule:**

--- a/content/docs/References/custommatch.md
+++ b/content/docs/References/custommatch.md
@@ -17,6 +17,7 @@ weight: 210
 
 Request to change the observer camera. Be aware of server conditions affecting request fulfillment.
 
+{{< alert context="info" text="For more information, consult the Protobuf documentation for your language of choice and look at details regarding the `oneof` field (https://protobuf.dev/programming-guides/proto3/#oneof)" />}}
 
 {{< table "table-striped-columns" >}}
 

--- a/content/docs/References/envelopemessages.md
+++ b/content/docs/References/envelopemessages.md
@@ -1,0 +1,101 @@
+{{< alert context="info" text="This documentation is a work in progress, and we actively welcome contributions. If you have suggestions for improvements or new features, feel free to open a pull request on our GitHub repository. [Contribute here](https://www.github.com/zeejayym/apex-liveapi-documentation). We appreciate your input in making our documentation better for everyone." />}}
+
+## Messages
+
+Messages that contain/envelope other game messages.
+
+### Request
+Envelope message for any Live API request. This allows a single uniform data structure for requests to be made and for the game to receive them. Specifically, there is only one possible action per request. You can request an acknowledgement of your request by setting `withAck` to true. Acknowledgements will come in the form of a Response message. More information can be found with that event.
+
+A single example to create a `CustomMatch_JoinLobby` request in python is as follows:
+```python
+req = Request()
+req.customMatch_JoinLobby.roleToken = "<some token>"
+req.withAck = True
+```
+
+{{< alert context="info" text="For more information, consult the Protobuf documentation for your language of choice and look at details regarding the `oneof` field (https://protobuf.dev/programming-guides/proto3/#oneof)" />}}
+
+#### Message Properties
+
+{{< table "table-striped-columns" >}}
+
+| Field Name  | Type    | Tag | Description                                                         |
+|-------------|---------|-----|---------------------------------------------------------------------|
+| `withAck`   | bool  | 1   | Receive an acknowledgement of the request having been received.    |
+| `preSharedKey`    | string  | 2   | Preshared key to use with the request. Only necessary if the connecting game has a preshared key specified through `cl_liveapi_requests_psk`.       |
+| `actions`            | oneof | -   | Action of Request (oneof options below table) |
+
+{{< /table >}}
+
+#### oneof Options
+Custom Match specific requests (reserved 10 -> 30)
+
+{{< table "table-striped-columns" >}}
+
+| Field Name                    | Type                        | Tag  | Description                             |
+|-------------------------------|-----------------------------|------|-----------------------------------------|
+| `changeCam`                   | ChangeCamera                | 4    | `ChangeCamera` message.                 |
+| `pauseToggle`                 | PauseToggle                 | 5    | `PauseToggle` message.                  |
+| `customMatch_CreateLobby`     | CustomMatch_CreateLobby     | 10   | `CustomMatch_CreateLobby` message.      |
+| `customMatch_JoinLobby`       | CustomMatch_JoinLobby       | 11   | `CustomMatch_JoinLobby` message.        |
+| `customMatch_LeaveLobby`      | CustomMatch_LeaveLobby      | 12   | `CustomMatch_LeaveLobby` message.       |
+| `customMatch_SetReady`        | CustomMatch_SetReady        | 13   | `CustomMatch_SetReady` message.         |
+| `customMatch_SetMatchmaking`  | CustomMatch_SetMatchmaking  | 14   | `CustomMatch_SetMatchmaking` message.   |
+| `customMatch_SetTeam`         | CustomMatch_SetTeam         | 15   | `CustomMatch_SetTeam` message.          |
+| `customMatch_KickPlayer`      | CustomMatch_KickPlayer      | 16   | `CustomMatch_KickPlayer` message.       |
+| `customMatch_SetSettings`     | CustomMatch_SetSettings     | 17   | `CustomMatch_SetSettings` message.      |
+| `customMatch_SendChat`        | CustomMatch_SendChat        | 18   | `CustomMatch_SendChat` message.         |
+| `customMatch_GetLobbyPlayers` | CustomMatch_GetLobbyPlayers | 19   | `CustomMatch_GetLobbyPlayers` message.  |
+| `customMatch_SetTeamName`     | CustomMatch_SetTeamName     | 20   | `CustomMatch_SetTeamName` message.      |
+| `customMatch_GetSettings`     | CustomMatch_GetSettings     | 21   | `CustomMatch_GetSettings` message.      |
+
+{{< /table >}}
+
+### Any
+Use [protobuf.dev's](https://protobuf.dev/reference/protobuf/google.protobuf/#any) documentation of the `Any` message for more information. This documentation will relate to its use in Apex LiveAPI. 
+
+{{< table "table-striped-columns" >}}
+
+| Field Name  | Type    | Tag | Description                                                         |
+|-------------|---------|-----|---------------------------------------------------------------------|
+| `type_url`   | string  | 1   | A URL that describes the type of the serialized message. LiveAPI messags use the `type.googleapis.com/rtech.liveapi.<MESSAGE TYPE>` format.    |
+| `value`    | bytes  | 2   | Serialized protocol buffer of the above specified type.       |
+
+{{< /table >}}
+
+### Response
+Message used to indicate the response to a request made to the API. Only the requesting part will receive this message and this message is only sent if the request required an acknowledgement by setting `withAck` to true in the Request object. This message is always sent within a `LiveAPIEvent` and never on its own to allow any applications to have a uniform method of reading events over the wire.
+
+{{< alert context="warning" text="If `success` is true, it does not mean that the Request has finished or that it was completed correctly. In this case, it means that it was successfully received and contains no issues (it is a well-formed request)." />}}
+
+{{< table "table-striped-columns" >}}
+
+| Field Name  | Type    | Tag | Description                                                         |
+|-------------|---------|-----|---------------------------------------------------------------------|
+| `success`   | bool  | 1   | Indicates if error has occurred.    |
+| `result`    | Any  | 3   |  Serialized protocol buffer of game message in an `Any` Message OR context of request in case of error. |
+
+{{< /table >}}
+
+### LiveAPIEvent
+Envelope for all LiveAPI Events. Any game events or responses to requests will be sent using this message. The specific event or message is stored in the `gameMessage` field.
+
+In order to read the message successfully, check the type contained in `gameMessage` and create an instance of that type where you can unpack the data to Protobuf has several ways of doing type to instance lookups that will allow you to do this after you've generated bindings. For example, to read and unpack any LiveAPIEvent in Python, the following can be done (assume `pb_msg` contains the LiveAPIEvent object):
+```python
+from events_pb2 import *
+from google.protobuf import symbol_database
+[ ... ]
+result_type = pb_msg.gameMessage.TypeName()
+msg_result = symbol_database.Default().GetSymbol(result_type)()
+pb_msg.gameMessage.Unpack(msg_result) # msg_result now holds the actual event you want to read
+```
+
+{{< table "table-striped-columns" >}}
+
+| Field Name  | Type    | Tag | Description                                                         |
+|-------------|---------|-----|---------------------------------------------------------------------|
+| `event_size`   | fixed32  | 1   | Size of protobuf event.    |
+| `gameMessage`    | Any  | 3   |  Serialized protocol buffer of game message in an `Any` Message |
+
+{{< /table >}}

--- a/content/docs/References/interactionevents.md
+++ b/content/docs/References/interactionevents.md
@@ -44,6 +44,22 @@ Occurs when a player finishes assisting a downed player.
 
 ### ArenasItemSelected
 
+Specific Arenas-only event that occurs when players select an item.
+
+{{< table "table-striped-columns" >}}
+
+| Field Name  | Type    | Tag | Description                                                 |
+|-------------|---------|-----|-------------------------------------------------------------|
+| `timestamp` | uint64  | 1   | The timestamp when the item was selected.                 |
+| `category`  | string  | 2   | The category of the event, e.g., "arenas_item_selected".  |
+| `player`    | Player  | 3   | The player who selected the item.                         |
+| `item`      | string  | 4   | The item selected.                                        |
+| `quantity`  | int32   | 5   | The quantity of the item selected.                        |
+
+{{< /table >}}
+
+### ArenasItemDeselected
+
 Specific Arenas-only event that occurs when players deselect an item.
 
 {{< table "table-striped-columns" >}}

--- a/content/docs/References/intermediarymessages.md
+++ b/content/docs/References/intermediarymessages.md
@@ -145,3 +145,13 @@ Response to the `CustomMatch_GetLobbyPlayers`, contains the list of all players 
 
 {{< /table >}}
 
+## RequestStatus
+Message used to indicate the status of a request. Generally, it is used to provide a plain text, detailed response in case of failures or problems
+
+{{< table "table-striped-columns" >}}
+
+| Field Name   | Type                         | Tag | Description                                                          |
+|--------------|------------------------------|-----|----------------------------------------------------------------------|
+| `status`     | string                       | 1   | A detailed response of a `Request` message.                          |
+
+{{< /table >}}

--- a/content/docs/References/observerevents.md
+++ b/content/docs/References/observerevents.md
@@ -13,7 +13,7 @@ weight: 240
 
 ## Messages
 
-### observerSwitched
+### ObserverSwitched
 
 Event when the observer camera switches from viewing one player to another
 

--- a/content/docs/acknowledgements/contributors.md
+++ b/content/docs/acknowledgements/contributors.md
@@ -19,7 +19,7 @@ This project is the result of hard work, passion, and dedication. From the botto
 
 - [**greeny**](https://github.com/RanomPanda) - Contributor
 - [**Slauka**](https://twitter.com/slaukie) - Tester
-- [**Spider**](https://github.com/StrongSpider) - Contributor
+- [**spiider**](https://github.com/StrongSpider) - Contributor
 - **Gabe** - Contributor
 - **Garrett** - Tester
 - **Kohl** - Contributor


### PR DESCRIPTION
### Documentation fixes:
- Fixed repo url in readme
- Added `ArenasItemSelected` message as well as fixing `ArenasItemDeselected`
- Fixed `ObserverSwitched` name for consistency

### EvelopeMessages:
I am not the biggest fan of this naming convention, but I saw it in one of the comments in the events.proto file and stuck with it. Its all the messages that come through that contain a GameMessage like `LiveAPIEvent` and `Request`.

- Created new page for EvelopeMessages (meta data needed for lotusdocs)
- Added alert for documentation of `oneof` type
- Added `RequestStatus` to IntermediaryMessages